### PR TITLE
tracker: allowing different paths (coefficient wise + straight line)

### DIFF
--- a/examples/rigidity_theory_example.jl
+++ b/examples/rigidity_theory_example.jl
@@ -10,6 +10,7 @@ R, (x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) = polynomial_ring(QQ, 10)
 M = matroid(linearMatrix)
 
 # define hypersurface supports
+# randseed!(31415296) # seed to reproduce bug
 targetSupports = Support[]
 for i in [1,2,3,4,5]
         pi = point([n in [i,i+5] ? 1 : 0 for n in 1:10])
@@ -22,7 +23,7 @@ push!(targetSupports, support([point([1,0,0,0,0,0,0,0,0,0]),point([0,0,0,0,0,0,0
 # define the target support
 targetSupport = mixed_support(targetSupports)
 Δ, σ = starting_data(targetSupport, M)
-T = tracker(Δ, targetSupport, [σ])
+T = tracker(Δ, targetSupport, [σ], path=:straight_line)
 
 # compute the stable intersection
 # 30x faster than Oscar stable intersection


### PR DESCRIPTION
Implements the straight line path, which is deterministic.  Also, found seed to reliably reproduce facet bug in `rigidity.jl`.