### PR TITLE
bug: chain of flats comparison

### DIFF
--- a/examples/rigidity_theory_example.jl
+++ b/examples/rigidity_theory_example.jl
@@ -10,7 +10,7 @@ R, (x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) = polynomial_ring(QQ, 10)
 M = matroid(linearMatrix)
 
 # define hypersurface supports
-# randseed!(31415296) # seed to reproduce bug
+randseed!(31415296) # seed to reproduce bug
 targetSupports = Support[]
 for i in [1,2,3,4,5]
         pi = point([n in [i,i+5] ? 1 : 0 for n in 1:10])


### PR DESCRIPTION
I am currently trying to optimise the maximal refinement code, and there is something weird.  Running `rigidity_theory_example.jl` yields `issetequal` saying no for two vectors of chains of flats even though the answer is clearly yes:

```
julia> include("examples/rigidity_theory_example.jl")
The maximal refinements do not match the new implementation
C: ∅ ⊊ {1, 2, 3} ⊊ {1, 2, 3, 8} ⊊ {1, 2, 3, 6, 7, 8} ⊊ {1, 2, 3, 4, 5, 6, 7, 8} ⊊ {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
result: ChainOfFlats[∅ ⊊ {3} ⊊ {1, 2, 3} ⊊ {1, 2, 3, 8} ⊊ {1, 2, 3, 6, 7, 8} ⊊ {1, 2, 3, 4, 5, 6, 7, 8} ⊊ {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, ∅ ⊊ {1} ⊊ {1, 2, 3} ⊊ {1, 2, 3, 8} ⊊ {1, 2, 3, 6, 7, 8} ⊊ {1, 2, 3, 4, 5, 6, 7, 8} ⊊ {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, ∅ ⊊ {2} ⊊ {1, 2, 3} ⊊ {1, 2, 3, 8} ⊊ {1, 2, 3, 6, 7, 8} ⊊ {1, 2, 3, 4, 5, 6, 7, 8} ⊊ {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}]
maximal_refinements_new(C): ChainOfFlats[∅ ⊊ {3} ⊊ {1, 2, 3} ⊊ {1, 2, 3, 8} ⊊ {1, 2, 3, 6, 7, 8} ⊊ {1, 2, 3, 4, 5, 6, 7, 8} ⊊ {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, ∅ ⊊ {2} ⊊ {1, 2, 3} ⊊ {1, 2, 3, 8} ⊊ {1, 2, 3, 6, 7, 8} ⊊ {1, 2, 3, 4, 5, 6, 7, 8} ⊊ {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, ∅ ⊊ {1} ⊊ {1, 2, 3} ⊊ {1, 2, 3, 8} ⊊ {1, 2, 3, 6, 7, 8} ⊊ {1, 2, 3, 4, 5, 6, 7, 8} ⊊ {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}]
```