### PR TITLE
Incorporating AbstractAlgebra's assertion and verbosity macros

### DIFF
--- a/examples/rigidity_theory_example.jl
+++ b/examples/rigidity_theory_example.jl
@@ -28,4 +28,5 @@ T = tracker(Δ, targetSupport, [σ], path=:straight_line)
 
 # compute the stable intersection
 # 30x faster than Oscar stable intersection
+AbstractAlgebra.set_verbosity_level(:TropicalHomotopies, 0)
 @time TropicalHomotopies.stable_intersection(T)

--- a/src/TropicalHomotopies.jl
+++ b/src/TropicalHomotopies.jl
@@ -28,4 +28,30 @@ include("homotopy.jl")
 include("starting_system.jl")
 include("exports.jl")
 
+function __init__()
+    # scope for overall homotopies
+    add_verbosity_scope(:TropicalHomotopies)
+    add_assertion_scope(:TropicalHomotopies)
+
+    # scope for starting data
+    add_verbosity_scope(:TropicalHomotopiesStart)
+    add_assertion_scope(:TropicalHomotopiesStart)
+
+    # scope for the general move
+    add_verbosity_scope(:TropicalHomotopiesMove)
+    add_assertion_scope(:TropicalHomotopiesMove)
+
+    # scope for Bergman related functions (time and move)
+    add_verbosity_scope(:TropicalHomotopiesBergman)
+    add_assertion_scope(:TropicalHomotopiesBergman)
+
+    # scope for Jensen related functions (time and move)
+    add_verbosity_scope(:TropicalHomotopiesJensen)
+    add_assertion_scope(:TropicalHomotopiesJensen)
+
+    # scope for perturbation
+    add_verbosity_scope(:TropicalHomotopiesPerturb)
+    add_assertion_scope(:TropicalHomotopiesPerturb)
+end
+
 end

--- a/src/homotopy.jl
+++ b/src/homotopy.jl
@@ -10,20 +10,20 @@ function move!(T::Tracker)
     update_number_of_moves!(T, 1)
 
     if isempty(mixed_cells(T))
-        @error "No mixed cells to move. Something went wrong."
+        @vprintln :TropicalHomotopiesMove 1 "No mixed cells to move. Something went wrong."
         return false
     end
-    @debug "Moving the tracker."
+    @vprintln :TropicalHomotopiesMove "Moving the tracker."
     # check if we have reached the target heights
     for p in points(ambient_support(T))
         if length(targets(T)) == 1 && all(ambient_support(T)[p] == first(targets(T))[p] for p in points(first(targets(T))))
-            @debug "Reached the target heights. Tropical homotopy algorithm complete."
+            @vprintln :TropicalHomotopiesMove 1 "Reached the target heights. Tropical homotopy algorithm complete."
             return false
         end
     end
 
     # work out which mixed cell(s) have minimal Bergman / Jensen time
-    @debug "Computing next flip time."
+    @vprintln :TropicalHomotopiesMove "Computing next flip time."
     # bergmanTimes and jensenTimes should be a dictionary mapping mixed cells to their times
     bergmanTimes = Dict{MixedCell, Height}()
     jensenTimes = Dict{MixedCell, Height}()
@@ -34,7 +34,7 @@ function move!(T::Tracker)
     smallestTBergman = minimum([value for (key, value) in bergmanTimes])
     smallestTJensen = minimum([value for (key, value) in jensenTimes])
     smallestT = min(smallestTBergman, smallestTJensen) # the time at which we perform flips
-    @debug "Next flip time is $smallestT."
+    @vprintln :TropicalHomotopiesMove "Next flip time is $smallestT."
 
     tTarget = 0
 
@@ -45,16 +45,16 @@ function move!(T::Tracker)
     end
 
     if smallestT >= tTarget
-        @debug "Flips happen after a target, so we need to check if we reached endgame or if a rebase needs to happen."
+        @vprintln :TropicalHomotopiesMove "Flips happen after a target, so we need to check if we reached endgame or if a rebase needs to happen."
         if isinf(tTarget)
-            @debug "Rebase needs to happen as we are sending a height to infinity."
+            @vprintln :TropicalHomotopiesMove "Rebase needs to happen as we are sending a height to infinity."
             # set the heights to the first target heights and remove it from the list
             update_number_of_rebases!(T, 1)
             rebase!(T, first(targets(T)))
-            @debug "Rebase complete."
+            @vprintln :TropicalHomotopiesMove "Rebase complete."
             return true
         else
-            @debug "No moves possible before reaching the target mixed subdivision. End game reached."
+            @vprintln :TropicalHomotopiesMove "No moves possible before reaching the target mixed subdivision. End game reached."
             # set the heights to the target heights
             add_heights!(T, direction(T))
             return false
@@ -62,36 +62,34 @@ function move!(T::Tracker)
     end
 
     if smallestTBergman < smallestTJensen
-        @debug "Bergman time is smaller than Jensen time."
+        @vprintln :TropicalHomotopiesMove "Bergman time is smaller than Jensen time."
     else
-        @debug "Jensen time is smaller than Bergman time."
+        @vprintln :TropicalHomotopiesMove "Jensen time is smaller than Bergman time."
     end
     if smallestTBergman == smallestTJensen && smallestTBergman == smallestT
         update_number_of_simultaneous_bergman_and_jensen_moves!(T, 1)
-        @debug "Both Bergman and Jensen times are equal. Performing both moves."
+        @vprintln :TropicalHomotopiesMove "Both Bergman and Jensen times are equal. Performing both moves."
     end
 
     changingBergmanMixedCells = [σ for σ in mixed_cells(T) if bergmanTimes[σ] == smallestT]
     changingJensenMixedCells = [σ for σ in mixed_cells(T) if jensenTimes[σ] == smallestT]
 
-    @debug "Mixed cells that are changing: Bergman cells: $(changingBergmanMixedCells) and Jensen cells: $(changingJensenMixedCells)."
+    @vprintln :TropicalHomotopiesMove "Mixed cells that are changing: Bergman cells: $(changingBergmanMixedCells) and Jensen cells: $(changingJensenMixedCells)."
 
     # these two lists should have empty intersection, if not, then a perturbation was required
     if !isempty(intersect(changingBergmanMixedCells, changingJensenMixedCells))
-        @debug "Intersection of Bergman and Jensen mixed cells is not empty. A perturbation was required."
-        println("Performing a perturbation.")
+        @vprintln :TropicalHomotopiesMove "Intersection of Bergman and Jensen mixed cells is not empty. A perturbation was required."
         perturb!(T, smallestT)
-        println("Perturbation complete.")
         return true
     end
 
     newMixedCells = MixedCell[]
 
     if smallestTBergman == smallestT
-        @debug "Performing Bergman move."
+        @vprintln :TropicalHomotopiesMove "Performing Bergman move."
         update_number_of_bergman_moves!(T, 1)
         for σ in changingBergmanMixedCells
-            @debug "Changing mixed cell: $σ."
+            @vprintln :TropicalHomotopiesMove "Changing mixed cell: $σ."
             bergmanFlipNewMixedCells = bergman_flip(T, σ, smallestTBergman)
             if isempty(bergmanFlipNewMixedCells)
                 # this means we need to perturb
@@ -99,16 +97,16 @@ function move!(T::Tracker)
                 return move!(T)
             end
             append!(newMixedCells, bergmanFlipNewMixedCells)
-            @debug "$(length(newMixedCells)) new mixed cells: $newMixedCells."
+            @vprintln :TropicalHomotopiesMove "$(length(newMixedCells)) new mixed cells: $newMixedCells."
             remove_mixed_cell!(T, σ)
         end
     end
     l = length(newMixedCells)
     if smallestTJensen == smallestT
-        @debug "Performing Jensen move."
+        @vprintln :TropicalHomotopiesMove "Performing Jensen move."
         update_number_of_jensen_moves!(T, 1)
         for σ in changingJensenMixedCells
-            @debug "Changing mixed cell: $σ."
+            @vprintln :TropicalHomotopiesMove "Changing mixed cell: $σ."
             jensenFlipNewMixedCells = jensen_flip(T, σ, smallestTJensen)
             if isempty(jensenFlipNewMixedCells)
                 # this means we need to perturb
@@ -116,47 +114,51 @@ function move!(T::Tracker)
                 return move!(T)
             end
             append!(newMixedCells, jensenFlipNewMixedCells)
-            @debug "$(length(newMixedCells) - l) new mixed cells: $(newMixedCells[l+1:end])."
+            @vprintln :TropicalHomotopiesMove "$(length(newMixedCells) - l) new mixed cells: $(newMixedCells[l+1:end])."
             remove_mixed_cell!(T, σ)
         end
     end
 
     # move the tracker to the heights achieved at the flip time
-    @debug "Moving the tracker to the heights achieved at the flip time."
+    @vprintln :TropicalHomotopiesMove "Moving the tracker to the heights achieved at the flip time."
     add_heights!(T, smallestT*direction(T))
 
     # check consistency of new cells
-    for σ in newMixedCells
-        @assert is_transverse(σ) "$(σ) is not transverse"
-        @assert are_support_heights_finite(T, σ) "$(σ) has invalid mixed height data"
-        @assert is_bergman_consistent(T, σ) "Cells are not Bergman consistent"
+    if AbstractAlgebra.get_assertion_level(:TropicalHomotopies)>0
+        for σ in mixed_cells(T)
+            @assert is_transverse(σ) "$(σ) is not transverse"
+            @assert are_support_heights_finite(T, σ) "$(σ) has invalid mixed height data"
+            @assert is_bergman_consistent(T, σ) "Cells are not Bergman consistent"
+        end
     end
 
-    @debug "New heights: $(dump_info(ambient_support(T)))."
+    @vprintln :TropicalHomotopiesMove "New heights: $(dump_info(ambient_support(T)))."
 
-    @debug "Merging $(length(newMixedCells)) new mixed cells."
+    @vprintln :TropicalHomotopiesMove "Merging $(length(newMixedCells)) new mixed cells."
     newMixedCellWasMerged = []
     for σ in newMixedCells
-        @debug "Merging mixed cell: $σ."
+        @vprintln :TropicalHomotopiesMove "Merging mixed cell: $σ."
         push!(newMixedCellWasMerged, merge_mixed_cell!(T, σ))
     end
 
-    # preFlipMultiplicities = sum(multiplicity.(changingBergmanMixedCells); init=0) + sum(multiplicity.(changingJensenMixedCells); init=0)
-    # postFlipMultiplicities = sum(multiplicity.(newMixedCells[findall(newMixedCellWasMerged)]); init=0)
+    if AbstractAlgebra.get_assertion_level(:TropicalHomotopiesMove)>1
+        preFlipMultiplicities = sum(multiplicity.(changingBergmanMixedCells); init=0) + sum(multiplicity.(changingJensenMixedCells); init=0)
+        postFlipMultiplicities = sum(multiplicity.(newMixedCells[findall(newMixedCellWasMerged)]); init=0)
 
-    # if preFlipMultiplicities != postFlipMultiplicities
-    #     println("The flips in this move have changed the local multiplicities. This is not allowed.")
-    #     println("Pre flip multiplicities: $(preFlipMultiplicities). Post flip multiplicities: $(postFlipMultiplicities).")
-    #     println("Multiplicities of Bergman mixed cells: $(multiplicity.(changingBergmanMixedCells)).")
-    #     println("Multiplicities of Jensen mixed cells: $(multiplicity.(changingJensenMixedCells)).")
-    #     println("Multiplicities of new mixed cells: $(multiplicity.(newMixedCells)).")
-    #     @assert false "Asserted, check output"
-    # end
+        if preFlipMultiplicities != postFlipMultiplicities
+            println("The flips in this move have changed the local multiplicities. This is not allowed.")
+            println("Pre flip multiplicities: $(preFlipMultiplicities). Post flip multiplicities: $(postFlipMultiplicities).")
+            println("Multiplicities of Bergman mixed cells: $(multiplicity.(changingBergmanMixedCells)).")
+            println("Multiplicities of Jensen mixed cells: $(multiplicity.(changingJensenMixedCells)).")
+            println("Multiplicities of new mixed cells: $(multiplicity.(newMixedCells)).")
+            @assert false "Asserted, check output"
+        end
+    end
 
     # update the cached jensen and bergman times for the mixed cells that didn't change
     update_cached_times!(T, newMixedCells, smallestT)
 
-    @debug "Tracker move successfully."
+    @vprintln :TropicalHomotopiesMove "Tracker move successfully."
 
     update_max_mixed_cells!(T, length(mixed_cells(T)))
 
@@ -170,11 +172,11 @@ end
 
 function stable_intersection(T::Tracker) # ::Vector{TropicalPoint}
     while move!(T)
-    @info "$(T.logger)"
-    println(length(mixed_cells(T)), " mixed cells being tracked")
+    @vprintln :TropicalHomotopies "$(T.logger)"
+    @vprintln :TropicalHomotopies "$(length(mixed_cells(T))) mixed cells being tracked"
     end
-    @info "$(T.logger)"
-    display(mixed_cells(T))
+    @vprintln :TropicalHomotopies "$(T.logger)"
+    @vprintln :TropicalHomotopies mixed_cells(T)
     mults = multiplicity.(mixed_cells(T))
     pts = [first(tropical_intersection_point_and_drift(T, σ)) for σ in mixed_cells(T)]
 

--- a/src/structs/chain_of_flats.jl
+++ b/src/structs/chain_of_flats.jl
@@ -284,9 +284,6 @@ function cone(C::ChainOfFlats)
     # add all ones vector
 
 
-    @debug "Equalities: $(equalities)"
-    @debug "Inequalities: $(inequalities)"
-
     # if length(equalities) == 0
     #     return cone_from_inequalities(Oscar.matrix(QQ, inequalities))
     # else

--- a/src/structs/mixed_support.jl
+++ b/src/structs/mixed_support.jl
@@ -77,7 +77,6 @@ function is_subset(S::MixedSupport, T::MixedSupport)
 
     for (s, t) in zip(supports(S), supports(T))
         if !is_subset(s, t)
-            @debug "Support $(s) is not a subset of $(t)"
             return false
         end
     end

--- a/src/structs/tracker.jl
+++ b/src/structs/tracker.jl
@@ -55,7 +55,7 @@ end
 function perturb!(T::Tracker, timeOfFailure::Height)
 
     @assert !isinf(timeOfFailure) "Time of failure should be finite"
-    println("time of failure = $(timeOfFailure)")
+    @vprintln :TropicalHomotopiesPerturb "time of failure = $(timeOfFailure)"
     dir = direction(T)
     add_heights!(T, (timeOfFailure / 2)*dir)
     # choose a random point in height space
@@ -89,16 +89,16 @@ function perturb!(T::Tracker, timeOfFailure::Height)
     smallestTBergman = minimum([value for (key, value) in bergmanTimes])
     smallestTJensen = minimum([value for (key, value) in jensenTimes])
     smallestT = min(smallestTBergman, smallestTJensen) # the time at which we perform flips
-    println("smallestT = $(smallestT)")
-    println("smallestTBergman = $(smallestTBergman)")
-    println("smallestTJensen = $(smallestTJensen)")
-    
+    @vprintln :TropicalHomotopiesPerturb "smallestT = $(smallestT)"
+    @vprintln :TropicalHomotopiesPerturb "smallestTBergman = $(smallestTBergman)"
+    @vprintln :TropicalHomotopiesPerturb "smallestTJensen = $(smallestTJensen)"
+
     dir = direction(newTracker)
-    show_heights(T)
-    println("Showing heights in direction between heights after first rebase and targetMixedSupport")
-    show_heights(dir)
+    @v_do :TropicalHomotopiesPerturb show_heights(T)
+    @vprintln :TropicalHomotopiesPerturb "Showing heights in direction between heights after first rebase and targetMixedSupport"
+    @v_do :TropicalHomotopiesPerturb show_heights(dir)
     add_heights!(T, (smallestT/2)*dir)
-    show_heights(T)
+    @v_do :TropicalHomotopiesPerturb show_heights(T)
     add_heights!(first(targets(T)), (smallestT/2)*dir)
 
     # delete all cached times

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,12 @@ using TropicalHomotopies
 using Test
 
 @testset "TropicalHomotopies.jl" begin
+    AbstractAlgebra.set_assertion_level(:TropicalHomotopies, 1)
+    AbstractAlgebra.set_assertion_level(:TropicalHomotopiesStart, 1)
+    AbstractAlgebra.set_assertion_level(:TropicalHomotopiesMove, 1)
+    AbstractAlgebra.set_assertion_level(:TropicalHomotopiesBergman, 1)
+    AbstractAlgebra.set_assertion_level(:TropicalHomotopiesJensen, 1)
+    AbstractAlgebra.set_assertion_level(:TropicalHomotopiesPerturb, 1)
 
     function straight_line_rigidity_example_test()
         # define matrix encoding linear ideal


### PR DESCRIPTION
To toggle the prints or assertions use `AbstractAlgebra.set_verbosity_level` and `AbstractAlgebra.set_assertion_level`:
https://docs.oscar-system.org/v1/AbstractAlgebra/assertions/

- All prints are behind verbosity level >0.
- Cheap assertions that were always enabled by default are behind assertion level >0 and are enabled in the test.  
- Expensive assertions that we commented out are behind assertion level >1.

The following scopes are currently being used:
```
    # scope for overall homotopies
    add_verbosity_scope(:TropicalHomotopies)
    add_assertion_scope(:TropicalHomotopies)

    # scope for starting data
    add_verbosity_scope(:TropicalHomotopiesStart)
    add_assertion_scope(:TropicalHomotopiesStart)

    # scope for the general move
    add_verbosity_scope(:TropicalHomotopiesMove)
    add_assertion_scope(:TropicalHomotopiesMove)

    # scope for Bergman related functions (time and move)
    add_verbosity_scope(:TropicalHomotopiesBergman)
    add_assertion_scope(:TropicalHomotopiesBergman)

    # scope for Jensen related functions (time and move)
    add_verbosity_scope(:TropicalHomotopiesJensen)
    add_assertion_scope(:TropicalHomotopiesJensen)

    # scope for perturbation
    add_verbosity_scope(:TropicalHomotopiesPerturb)
    add_assertion_scope(:TropicalHomotopiesPerturb)
```