### PR TITLE
chg: consolidating existing and adding missing imports

### DIFF
--- a/examples/rigidity_theory_example.jl
+++ b/examples/rigidity_theory_example.jl
@@ -1,5 +1,4 @@
 using TropicalHomotopies
-import Oscar.matrix, Oscar.echelon_form, Oscar.QQ, Oscar.polynomial_ring, Oscar.randseed!, Oscar.set_seed!
 
 # define matrix encoding linear ideal
 linearMatrix = matrix(QQ, [1 1 0 0 0 0 0 0 0 0; -1 0 -1 -1 0 0 0 0 0 0; 0 -1 1 0 -1 0 0 0 0 0; 0 0 0 1 1 0 0 0 0 0; 0 0 0 0 0 1 1 0 0 0; 0 0 0 0 0 -1 0 -1 -1 0; 0 0 0 0 0 0 -1 1 0 -1; 0 0 0 0 0 0 0 0 1 1])
@@ -10,9 +9,9 @@ R, (x1,x2,x3,x4,x5,x6,x7,x8,x9,x10) = polynomial_ring(QQ, 10)
 M = matroid(linearMatrix)
 
 # define hypersurface supports
-# randseed!(31415296) # seed to reproduce bug (2 mixed cells)
-# randseed!(127) # 3 mixed cells at the end
-randseed!(143)
+# Oscar.randseed!(31415296) # seed to reproduce bug (2 mixed cells)
+# Oscar.randseed!(127) # 3 mixed cells at the end
+Oscar.randseed!(143)
 targetSupports = Support[]
 for i in [1,2,3,4,5]
         pi = TropicalHomotopies.point([n in [i,i+5] ? 1 : 0 for n in 1:10])

--- a/src/TropicalHomotopies.jl
+++ b/src/TropicalHomotopies.jl
@@ -2,6 +2,13 @@ module TropicalHomotopies
 
 using Oscar
 
+# the following functions in Oscar will be extended:
+import Oscar:
+    dot,
+    flats,
+    matrix,
+    stable_intersection
+
 include("structs/point.jl")
 include("structs/height.jl")
 include("structs/support.jl")

--- a/src/structs/chain_of_flats.jl
+++ b/src/structs/chain_of_flats.jl
@@ -31,7 +31,6 @@ function matroid(C::ChainOfFlats)
     return C.matroid
 end
 
-import Oscar.flats
 @doc raw"""
     flats(C::ChainOfFlats)
 

--- a/src/structs/mixed_cell_cone.jl
+++ b/src/structs/mixed_cell_cone.jl
@@ -208,8 +208,6 @@ function Base.convert(::Type{Polyhedron}, C::MixedCellCone)
     return polyhedron(A, b)
 end
 
-import Oscar.dot
-
 function dot(Δ::MixedSupport, κ::MixedCellConeFacet)
     return sum([QQ(circuit(κ)[p]) * QQ(Δ[p]) for p in keys(circuit(κ)) if !isinf(Δ[p])])
 end

--- a/src/structs/realisable_matroid.jl
+++ b/src/structs/realisable_matroid.jl
@@ -52,7 +52,6 @@ function ground_set(M::RealisableMatroid)
     return Set{Int}(1:ncols(matrix(M)))
 end
 
-import Oscar.flats
 @doc raw"""
     flats(M::RealisableMatroid)
 

--- a/src/structs/support.jl
+++ b/src/structs/support.jl
@@ -154,7 +154,6 @@ function support(f::TropicalPolynomial)::Support
 
 end
 
-import Oscar.dot
 function dot(w::TropicalPoint, p::Point)
     return sum(w .* entries(p))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,8 @@
+using Oscar
 using TropicalHomotopies
 using Test
 
 @testset "TropicalHomotopies.jl" begin
-    import Oscar.matrix, Oscar.echelon_form, Oscar.QQ, Oscar.polynomial_ring, Oscar.randseed!, Oscar.set_seed!
 
     function straight_line_rigidity_example_test()
         # define matrix encoding linear ideal
@@ -14,15 +14,15 @@ using Test
         M = matroid(linearMatrix)
 
         # define hypersurface supports
-        randseed!(31415296) # seed to reproduce bug
+        Oscar.randseed!(31415296) # seed to reproduce bug
         targetSupports = Support[]
         for i in [1,2,3,4,5]
-                pi = point([n in [i,i+5] ? 1 : 0 for n in 1:10])
-                p0 = point([0 for n in 1:10])
-                    push!(targetSupports, support([pi,p0],[0,0]))
+                pi = TropicalHomotopies.point([n in [i,i+5] ? 1 : 0 for n in 1:10])
+                p0 = TropicalHomotopies.point([0 for n in 1:10])
+                    push!(targetSupports, TropicalHomotopies.support([pi,p0],[0,0]))
         end
         # add an extra hypersurface to cut the common lineality space
-        push!(targetSupports, support([point([1,0,0,0,0,0,0,0,0,0]),point([0,0,0,0,0,0,0,0,0,0])],[1,3]))
+        push!(targetSupports, TropicalHomotopies.support([TropicalHomotopies.point([1,0,0,0,0,0,0,0,0,0]),TropicalHomotopies.point([0,0,0,0,0,0,0,0,0,0])],[1,3]))
 
         # define the target support
         targetSupport = mixed_support(targetSupports)


### PR DESCRIPTION
It seemed some imports from Oscar were missing, which required the `import Oscar.foo` in `rigidity_theory_example.jl` and `runtest.jl`.  This PR should fix that. 