### PR TITLE
Fix Oscar v1.7 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,9 @@ version = "1.0.0-DEV"
 
 [deps]
 Oscar = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
-Oscar = "1.2.2"
-Revise = "3.7.3"
+Oscar = "1.2.2, 1.7"
 julia = "1.6.7"
 
 [extras]

--- a/src/bergman_flip.jl
+++ b/src/bergman_flip.jl
@@ -141,7 +141,7 @@ function bergman_flip(T::Tracker, σ::MixedCell, tBergman::Height)
         # assemble and solve the combined affine linear system from the Bergman linear equations
         # and the jensen affine linear equations
         affineLinearEquationsLHS = vcat(bergmanConeSpanLinearEquations, jensenStarLinearEquationMatrix)
-        affineLinearEquationsRHS = vcat(zeros(QQ, nrows(bergmanConeSpanLinearEquations)), jensenStarAffineEquationsRHS)
+        affineLinearEquationsRHS = vcat(fill(zero(QQ), nrows(bergmanConeSpanLinearEquations)), jensenStarAffineEquationsRHS)
         canSolve, solution, kernelGenerators = Oscar.can_solve_with_solution_and_kernel(affineLinearEquationsLHS, affineLinearEquationsRHS; side=:right)
 
         # check whether the combined affine linear system has exactly one solution.

--- a/src/starting_system.jl
+++ b/src/starting_system.jl
@@ -147,7 +147,7 @@ function find_tropical_point(polynomials::Vector{TropicalPolynomial}, M::Realisa
     equationsMatrix = vcat(R.(linearIdealMatrix), A)
 
     # right hand side of the equations is 0 for the matroid parts
-    b = zeros(R, nrows(equationsMatrix))
+    b = [zero(R) for _ in 1:nrows(equationsMatrix)]
     for i in 1:nrows(linearIdealMatrix)
         b[i] = R(0)
     end
@@ -167,14 +167,14 @@ function find_tropical_point(polynomials::Vector{TropicalPolynomial}, M::Realisa
 end
 
 function random_lift(nu::TropicalSemiringMap, a::TropicalSemiringElem=tropical_semiring(nu)(rand(Int8)))
-
     aInt = ZZ(a; preserve_ordering=true)
-    randomLift = rand(-999:999)*Oscar.uniformizer_field(nu)^aInt
+    R = Oscar.valued_field(nu)
+    u = R(Oscar.uniformizer(nu))
+    randomLift = rand(-999:999)*u^aInt
     while iszero(randomLift)
-        randomLift = rand(-999:999)*Oscar.uniformizer_field(nu)^aInt
+        randomLift = rand(-999:999)*u^aInt
     end
     return randomLift
-
 end
 
 @doc raw"""

--- a/src/structs/chain_of_flats.jl
+++ b/src/structs/chain_of_flats.jl
@@ -263,7 +263,7 @@ function cone(C::ChainOfFlats)
     for (i, F) in enumerate(reducedFlats)
         F1, Frest = Iterators.peel(F)
         for Fj in Frest
-            equality = zeros(QQ, length(ground_set(matroid(C))))
+            equality = fill(zero(QQ), length(ground_set(matroid(C))))
             equality[F1] = 1
             equality[Fj] = -1
             push!(equalities, equality)
@@ -272,7 +272,7 @@ function cone(C::ChainOfFlats)
         for j in 1:(i-1)
             G = reducedFlats[j]
             for g in G
-                inequality = zeros(QQ, length(ground_set(matroid(C))))
+                inequality = fill(zero(QQ), length(ground_set(matroid(C))))
                 inequality[g] = -1
                 inequality[F1] = 1
                 push!(inequalities, inequality)
@@ -488,7 +488,7 @@ function tropical_equalities(C::ChainOfFlats)
     for F in reducedFlats
         F1, Frest = Iterators.peel(F)
         for Fj in Frest
-            equality = zeros(QQ, length(ground_set(matroid(C))))
+            equality = fill(zero(QQ), length(ground_set(matroid(C))))
             equality[F1] = 1
             equality[Fj] = -1
             push!(equalities, equality)

--- a/src/structs/mixed_cell.jl
+++ b/src/structs/mixed_cell.jl
@@ -210,7 +210,7 @@ function tropical_polyhedra_spans_and_mults(σ::MixedCell)
     cols = Vector{QQFieldElem}[]
     push!(cols, indicator_vector.(full_flats(chain_of_flats(σ)))...)
     # remove all zero vector from cols
-    cols = [col for col in cols if col != zeros(QQ, length(col))]
+    cols = [col for col in cols if !iszero(col)]
     A = Oscar.matrix(QQ, cols)
 
 


### PR DESCRIPTION
Make the package work for the latest version of Oscar to attempt to address performance issues.

## Summary
- Replace removed `Oscar.uniformizer_field(nu)` with `Oscar.valued_field(nu)` + `Oscar.uniformizer(nu)` in `random_lift`
- Fix deprecated `zeros(R, n)` calls across the codebase (use `fill(zero(R), n)` / `iszero`)
- Remove `Revise` from hard dependencies (dev tool, not runtime)
- Update Oscar compat bounds to include v1.7

## Test plan
- [x] `Pkg.test()` passes; rigidity theory example completes with `sum(Sigma[2]) == 4`
- [x] No deprecation warnings during test run